### PR TITLE
 fix: patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ def versions = [
   camel               : '3.8.0',
   gradlePitest        : '1.5.1',
   pitest              : '1.7.0',
-  log4j               : '2.15.0'
+  log4j               : '2.16.0'
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-3799

### Change description ###

patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```