### PR TITLE
CRD: Drop existing view and tables for List Of Values

### DIFF
--- a/src/main/resources/db/migration/V1_3__drop_view_table_mv_list_of_values.sql
+++ b/src/main/resources/db/migration/V1_3__drop_view_table_mv_list_of_values.sql
@@ -1,0 +1,11 @@
+DROP MATERIALIZED VIEW mv_list_of_values;
+DROP TABLE hearing_channel;
+DROP TABLE hearing_type;
+DROP TABLE hearing_priority;
+DROP TABLE non_standard_duration_codes;
+DROP TABLE case_type;
+DROP TABLE cancellation_reasons;
+DROP TABLE interpreter_and_sign_language;
+DROP TABLE additional_facilities;
+DROP TABLE panel_member_type;
+COMMIT;

--- a/src/main/resources/db/migration/V1_5__drop_view_table_mv_list_of_values.sql
+++ b/src/main/resources/db/migration/V1_5__drop_view_table_mv_list_of_values.sql
@@ -8,4 +8,5 @@ DROP TABLE cancellation_reasons;
 DROP TABLE interpreter_and_sign_language;
 DROP TABLE additional_facilities;
 DROP TABLE panel_member_type;
+DROP TABLE entity_role_codes;
 COMMIT;


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ### https://tools.hmcts.net/jira/browse/RDCC-4231



### Change description ### 
This involves the following :

Drop all the below tables for list of values
            a. hearing_channel

            b. hearing_type

            c. hearing_priority

            d. non_standard_duration_codes

            e. case_type

            f. cancellation_reasons

            g. interpreter_and_sign_language

            h. additional_facilities

            i. panel_member_type

            j. additional_facilities

      2. Drop the existing view (mv_list_of_values) for List Of Values.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
