### PR TITLE
fix: RDCC-4670 Fixed CVE-2022-24823 by upgrading netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -397,7 +397,7 @@ configurations.all {
   resolutionStrategy.eachDependency { details ->
     if (details.requested.group == 'io.netty'
       && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-      details.useVersion "4.1.69.Final"
+      details.useVersion "4.1.77.Final"
     }
 
     // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-4670

### Change description ###
Fixed CVE-2022-24823 by upgrading netty


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```