### PR TITLE
RDCC-5357 Handling 'D' records in pre-processor logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessor.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.rd.commondata.camel.binder.Categories;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -138,26 +137,26 @@ public class CategoriesProcessor extends JsrValidationBaseProcessor<Categories> 
         boolean activeProcessed = false;
 
         for (Categories category : categoriesList) {
-                if ((category.getActive().equalsIgnoreCase("Y")
+            if ((category.getActive().equalsIgnoreCase("Y")
                     && !activeProcessed)) {
-                    validCategories.add(category);
-                    activeProcessed = true;
-                } else {
-                    //process 'D' logic records
-                    if (category.getActive().equalsIgnoreCase("D")
+                validCategories.add(category);
+                activeProcessed = true;
+            } else {
+                //process 'D' logic records
+                if (category.getActive().equalsIgnoreCase("D")
                         && Boolean.TRUE.equals(deleteFlagValidation(activeCategories, category))) {
-                        validCategories = validCategories.stream()
+                    validCategories = validCategories.stream()
                             .filter(categories -> !categories.getActive().equalsIgnoreCase("Y"))
                             .collect(Collectors.toList());
-                        validCategories.add(category);
-                    }
+                    validCategories.add(category);
                 }
+            }
         }
         return validCategories;
     }
 
     private Boolean deleteFlagValidation(Categories activeCategories, Categories category) {
-        boolean isActive = activeCategories != null? Boolean.TRUE : Boolean.FALSE;
+        boolean isActive = activeCategories != null ? Boolean.TRUE : Boolean.FALSE;
         return isActive && activeCategories.getValueEN().equalsIgnoreCase(category.getValueEN());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/rd/commondata/camel/util/CommonDataLoadConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/rd/commondata/camel/util/CommonDataLoadConstants.java
@@ -18,4 +18,5 @@ public final class CommonDataLoadConstants {
         "SELECT categorykey, key, serviceid FROM list_of_values WHERE TRIM(active) = ?";
     public static final String DELETE_CATEGORY_BY_STATUS =
         "DELETE FROM list_of_values WHERE TRIM(active) = ?";
+    public static final String ACTIVE_Y = "Y";
 }

--- a/src/test/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessorTest.java
@@ -85,7 +85,7 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
 
     @Test
     @DisplayName("Test for LOV Duplicate records Case1")
-    void testListOfValuesCsv_DupRecord_Case1() throws Exception {
+    void testListOfValuesCsv_DupRecord_Case1() {
         var lovServiceList = new ArrayList<Categories>();
         lovServiceList.addAll(getLovServicesCase1());
 
@@ -101,7 +101,7 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
 
     @Test
     @DisplayName("Test for LOV Duplicate records Case2")
-    void testListOfValuesCsv_DupRecord_Case2() throws Exception {
+    void testListOfValuesCsv_DupRecord_Case2() {
         var lovServiceList = new ArrayList<Categories>();
         lovServiceList.addAll(getLovServicesCase2());
 
@@ -114,7 +114,23 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
 
         List actualLovServiceList = (List) exchange.getMessage().getBody();
         Assertions.assertEquals(1, actualLovServiceList.size());
+    }
 
+    @Test
+    @DisplayName("Test for LOV 'D' records Case3")
+    void testListOfValuesCsv_DupRecord_Case3() throws Exception {
+        var lovServiceList = new ArrayList<Categories>();
+        lovServiceList.addAll(getLovServicesCase3());
+
+        exchange.getIn().setBody(lovServiceList);
+        when(((ConfigurableApplicationContext)
+            applicationContext).getBeanFactory()).thenReturn(configurableListableBeanFactory);
+
+        processor.process(exchange);
+        verify(processor, times(1)).process(exchange);
+
+        List actualLovServiceList = (List) exchange.getMessage().getBody();
+        Assertions.assertEquals(1, actualLovServiceList.size());
     }
 
     private List<Categories> getLovServicesCase1() {
@@ -146,7 +162,7 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
                 .categoryKey("caseSubType")
                 .serviceId("BBA3")
                 .key("BBA3-001AD")
-                .valueEN("ADVANCE PAYMENT new")
+                .valueEN("ADVANCE PAYMENT")
                 .parentCategory("caseType")
                 .parentKey("BBA3-001")
                 .active("D")
@@ -168,6 +184,29 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
                 .parentCategory("caseType")
                 .parentKey("BBA3-001")
                 .active("N")
+                .build()
+        );
+    }
+
+    private List<Categories> getLovServicesCase3() {
+        return ImmutableList.of(
+            Categories.builder()
+                .categoryKey("caseSubType")
+                .serviceId("BBA3")
+                .key("BBA3-001AD")
+                .valueEN("ADVANCE PAYMENT")
+                .parentCategory("caseType")
+                .parentKey("BBA3-001")
+                .active("Y")
+                .build(),
+            Categories.builder()
+                .categoryKey("caseSubType")
+                .serviceId("BBA3")
+                .key("BBA3-001AD")
+                .valueEN("ADVANCE PAYMENT new")
+                .parentCategory("caseType")
+                .parentKey("BBA3-001")
+                .active("D")
                 .build()
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/rd/commondata/camel/processor/CategoriesProcessorTest.java
@@ -203,7 +203,7 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.ROU
                 .categoryKey("caseSubType")
                 .serviceId("BBA3")
                 .key("BBA3-001AD")
-                .valueEN("ADVANCE PAYMENT new")
+                .valueEN("ADVANCE PAYMENT")
                 .parentCategory("caseType")
                 .parentKey("BBA3-001")
                 .active("D")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-5357


### Change description ###
Common : Update the duplicate check logic in ETL ingestion for LoV


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
