### PR TITLE
RDCC-5778: Upgrading `tomcat` to version `9.0.68`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ dependencyManagement {
       entry 'guava'
     }
 
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5778

### Change description ###

Upgrading `tomcat` to version `9.0.68` to fix CVE-2022-42252

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
