### PR TITLE
RDCC-6130: Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,4 +38,9 @@
     <notes>cucumber:datatable pom contains com.googlecode.java-diff-utils:diffutils which has the CVE vulnerability, no fix has been released yet for this</notes>
     <cve>CVE-2021-4277</cve>
   </suppress>
+      <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6130

### Change description ###

Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
