### PR TITLE
DTSRD-1456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -442,11 +442,6 @@ applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
 // Fix for CVE-2021-21295 & need to be removed with new Azure blob version
 configurations.all {
   resolutionStrategy.eachDependency { details ->
-    if (details.requested.group == 'io.netty'
-      && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-      details.useVersion "4.1.94.Final"
-    }
-
     // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library
     if (details.requested.group == 'com.ibm.icu') {
       details.useVersion "66.1"
@@ -472,6 +467,20 @@ dependencyManagement {
       entry 'jackson-databind'
       entry 'jackson-core'
       entry 'jackson-annotations'
+    }
+
+    //        Resolves CVE-2023-4586
+    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+      entry 'netty-buffer'
+      entry 'netty-codec'
+      entry 'netty-codec-http'
+      entry 'netty-codec-socks'
+      entry 'netty-common'
+      entry 'netty-handler'
+      entry 'netty-handler-proxy'
+      entry 'netty-resolver'
+      entry 'netty-transport'
+      entry 'netty-transport-native-unix-common'
     }
   }
 }

--- a/charts/rd-commondata-dataload/Chart.yaml
+++ b/charts/rd-commondata-dataload/Chart.yaml
@@ -3,12 +3,12 @@ appVersion: "1.0"
 description: A Helm chart for rd-commondata-dataload
 name: rd-commondata-dataload
 home: https://github.com/hmcts/rd-commondata-dataload
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: Reference Data Team
 dependencies:
   - name: job
-    version: 1.0.0
+    version: 1.1.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 11.6.10


### PR DESCRIPTION
- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-1456

### Change description ###

- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
